### PR TITLE
feat: align document_chunk embedding dimension & rebuild ANN index

### DIFF
--- a/backend/alembic/versions/0003_align_embedding_dimension.py
+++ b/backend/alembic/versions/0003_align_embedding_dimension.py
@@ -1,0 +1,42 @@
+"""Align document_chunk embedding vector dimension with runtime model."""
+
+from alembic import op
+
+
+revision = "0003_align_embedding_dimension"
+down_revision = "0002_vector_768_hnsw"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DROP INDEX IF EXISTS idx_document_chunk_embedding;
+        DROP INDEX IF EXISTS idx_document_chunk_embedding_hnsw;
+
+        ALTER TABLE document_chunk
+          ALTER COLUMN embedding TYPE vector(768);
+
+        CREATE INDEX IF NOT EXISTS idx_document_chunk_embedding_hnsw
+          ON document_chunk USING hnsw (embedding vector_cosine_ops);
+
+        ANALYZE document_chunk;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DROP INDEX IF EXISTS idx_document_chunk_embedding_hnsw;
+
+        ALTER TABLE document_chunk
+          ALTER COLUMN embedding TYPE vector(1536);
+
+        CREATE INDEX IF NOT EXISTS idx_document_chunk_embedding
+          ON document_chunk USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+
+        ANALYZE document_chunk;
+        """
+    )


### PR DESCRIPTION
Embedding Alignment (2025-09-18)
- Confirmed gemma:2b-embeddings emits 768-d vectors and applied Alembic revision 0003_align_embedding_dimension.py to set document_chunk.embedding -> vector(768) and rebuild idx_document_chunk_embedding_hnsw.
- Rebuilt api image and reran smoke: GET /health/schema -> 200 (2025-09-18T01:49:50Z); GET /api/v1/tools with dev header -> 200 returning seeded summarize_tool. Logs clean.
- Ready to tackle the remaining [ ] entries from scripts/list_schema_mapping.py (user_auth, user_settings, user_identity, organization*, library_document/document_chunk, etc.).