### PR TITLE
Add Monaco editor component and integrate into tool creation page

### DIFF
--- a/web/src/lib/components/MonacoEditor.svelte
+++ b/web/src/lib/components/MonacoEditor.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+  import type { editor as EditorNS, IDisposable } from 'monaco-editor';
+
+  type Monaco = typeof import('monaco-editor');
+
+  export let value = '';
+  export let language = 'python';
+  export let theme = 'vs-dark';
+  export let readOnly = false;
+  export let ariaLabel = 'Code editor';
+  export let ariaLabelledby: string | undefined = undefined;
+  export let options: Partial<EditorNS.IStandaloneEditorConstructionOptions> = {};
+  export let height: number | string = '320px';
+  export let id: string | undefined = undefined;
+  export let className = '';
+  export let loadingMessage = 'Loading editor…';
+
+  const dispatch = createEventDispatcher<{
+    change: { value: string };
+    input: { value: string };
+  }>();
+
+  let container: HTMLDivElement | null = null;
+  let editor: EditorNS.IStandaloneCodeEditor | null = null;
+  let monaco: Monaco | null = null;
+  let ready = false;
+  let disposables: IDisposable[] = [];
+  let hiddenTextarea: HTMLTextAreaElement | null = null;
+
+  const resolveHeight = () => (typeof height === 'number' ? `${height}px` : height);
+  let containerStyle = `height: ${resolveHeight()};`;
+
+  $: containerStyle = `height: ${resolveHeight()};`;
+
+  async function initializeEditor() {
+    if (!container) return;
+    const monacoModule = await import('monaco-editor');
+    if (!container) return;
+
+    monaco = monacoModule;
+    monaco.editor.setTheme(theme);
+
+    editor = monaco.editor.create(container, {
+      value,
+      language,
+      readOnly,
+      automaticLayout: true,
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      fontSize: 14,
+      tabSize: 2,
+      smoothScrolling: true,
+      accessibilitySupport: 'on',
+      ...options,
+    });
+
+    const domNode = editor.getDomNode();
+    if (domNode) {
+      domNode.setAttribute('aria-label', ariaLabel);
+      if (ariaLabelledby) {
+        domNode.setAttribute('aria-labelledby', ariaLabelledby);
+      } else {
+        domNode.removeAttribute('aria-labelledby');
+      }
+    }
+
+    disposables = [
+      editor.onDidChangeModelContent(() => {
+        const newValue = editor?.getValue() ?? '';
+        if (newValue !== value) {
+          value = newValue;
+          dispatch('input', { value: newValue });
+          dispatch('change', { value: newValue });
+        }
+      }),
+    ];
+
+    ready = true;
+  }
+
+  function cleanup() {
+    disposables.forEach((d) => d.dispose());
+    disposables = [];
+    editor?.dispose();
+    editor = null;
+    ready = false;
+  }
+
+  export function focus() {
+    if (editor) {
+      editor.focus();
+    } else if (hiddenTextarea) {
+      hiddenTextarea.focus();
+    } else if (container) {
+      container.focus();
+    }
+  }
+
+  function handleHiddenFocus() {
+    if (editor) {
+      editor.focus();
+    }
+    if (hiddenTextarea) {
+      hiddenTextarea.blur();
+    }
+  }
+
+  onMount(() => {
+    initializeEditor();
+    return () => cleanup();
+  });
+
+  onDestroy(() => {
+    cleanup();
+  });
+
+  $: if (editor && value !== editor.getValue()) {
+    editor.setValue(value ?? '');
+  }
+
+  $: if (editor) {
+    editor.updateOptions({ readOnly, ...options });
+    const domNode = editor.getDomNode();
+    if (domNode) {
+      domNode.setAttribute('aria-label', ariaLabel);
+      if (ariaLabelledby) {
+        domNode.setAttribute('aria-labelledby', ariaLabelledby);
+      } else {
+        domNode.removeAttribute('aria-labelledby');
+      }
+    }
+  }
+
+  $: if (editor && monaco) {
+    const model = editor.getModel();
+    if (model && model.getLanguageId() !== language) {
+      monaco.editor.setModelLanguage(model, language);
+    }
+  }
+
+  $: if (monaco) {
+    monaco.editor.setTheme(theme);
+  }
+
+  $: if (hiddenTextarea && hiddenTextarea.value !== value) {
+    hiddenTextarea.value = value ?? '';
+  }
+</script>
+
+{#if id}
+  <textarea
+    bind:this={hiddenTextarea}
+    id={id}
+    class="monaco-editor-hidden-textarea"
+    value={value}
+    tabindex="0"
+    aria-hidden="true"
+    on:focus={handleHiddenFocus}
+    readonly
+  ></textarea>
+{/if}
+
+<div
+  bind:this={container}
+  class={`monaco-editor-shell ${className}`.trim()}
+  style={containerStyle}
+  data-ready={ready}
+  role="group"
+  aria-busy={ready ? 'false' : 'true'}
+  aria-label={!ready ? ariaLabel : undefined}
+  aria-labelledby={ariaLabelledby}
+>
+  {#if !ready}
+    <span class="editor-loading" aria-live="polite">{loadingMessage}</span>
+  {/if}
+</div>
+
+<style>
+  .monaco-editor-hidden-textarea {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    border: 0;
+    white-space: nowrap;
+  }
+
+  .monaco-editor-shell {
+    width: 100%;
+    position: relative;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    min-height: 200px;
+  }
+
+  .monaco-editor-shell[data-ready='false'] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #9ca3af;
+    font-size: 0.875rem;
+  }
+
+  .monaco-editor-shell :global(.monaco-editor),
+  .monaco-editor-shell :global(.monaco-editor-background),
+  .monaco-editor-shell :global(.monaco-editor .overflow-guard) {
+    position: absolute;
+    inset: 0;
+  }
+
+  .editor-loading {
+    text-align: center;
+    padding: 1rem;
+  }
+</style>

--- a/web/src/routes/creation-station/tools/new/+page.svelte
+++ b/web/src/routes/creation-station/tools/new/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { creationAPI } from '$lib/api.creationstation';
   import { goto } from '$app/navigation';
+  import MonacoEditor from '$lib/components/MonacoEditor.svelte';
 
   let slug = '';
   let name = '';
@@ -93,7 +94,7 @@
     <section class="form-panel">
       <header class="panel-header">
         <div class="header-left">
-          <a href="/creation-station/tools" class="back-link">
+          <a href="/creation-station/tools" class="back-link" aria-label="Back to tools">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M19 12H5M12 19l-7-7 7-7"/>
             </svg>
@@ -155,14 +156,17 @@
         </div>
 
         <div class="form-group">
-          <label for="content">CODE</label>
-          <textarea 
-            id="content" 
-            bind:value={content} 
-            rows="12"
-            class="form-textarea code-editor"
-            spellcheck="false"
-          ></textarea>
+          <label id="content-label" for="content-editor">CODE</label>
+          <div class="code-editor-wrapper">
+            <MonacoEditor
+              id="content-editor"
+              bind:value={content}
+              language={language}
+              ariaLabel="Tool code editor"
+              ariaLabelledby="content-label"
+              height="360px"
+            />
+          </div>
         </div>
 
         <div class="form-group">
@@ -251,7 +255,7 @@
             placeholder="Ask ToolForge for help..."
             class="chat-input"
           />
-          <button on:click={sendMessage} class="send-btn">
+          <button on:click={sendMessage} class="send-btn" aria-label="Send message">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="22" y1="2" x2="11" y2="13"></line>
               <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
@@ -387,6 +391,7 @@
     color: #d1d5db;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+    cursor: pointer;
   }
 
   .form-input,
@@ -413,15 +418,43 @@
     background: rgba(31, 41, 55, 0.7);
   }
 
+  .code-editor-wrapper {
+    background: rgba(31, 41, 55, 0.5);
+    border: 1px solid rgba(75, 85, 99, 0.5);
+    border-radius: 0.5rem;
+    transition: all 0.2s;
+    min-height: 360px;
+    overflow: hidden;
+  }
+
+  .code-editor-wrapper:focus-within {
+    border-color: rgba(139, 92, 246, 0.5);
+    background: rgba(31, 41, 55, 0.7);
+    box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.15);
+  }
+
+  .code-editor-wrapper :global(.monaco-editor),
+  .code-editor-wrapper :global(.monaco-editor .overflow-guard) {
+    background-color: transparent !important;
+  }
+
+  .code-editor-wrapper :global(.monaco-editor .margin) {
+    background-color: rgba(17, 24, 39, 0.7);
+  }
+
+  .code-editor-wrapper :global(.monaco-editor .line-numbers) {
+    color: #9ca3af;
+  }
+
+  .code-editor-wrapper :global(.monaco-editor .view-lines) {
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-size: 0.875rem;
+  }
+
   .form-textarea {
     resize: vertical;
     font-family: inherit;
     line-height: 1.5;
-  }
-
-  .code-editor {
-    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-    font-size: 0.875rem;
   }
 
   .form-row {


### PR DESCRIPTION
## Summary
- add a reusable `MonacoEditor` Svelte component that dynamically loads monaco-editor, synchronises value changes, and preserves accessibility hooks for labels and focus management
- replace the textarea on the new tool form with the Monaco editor component and update styling to keep the layout cohesive while improving keyboard/a11y affordances
- add aria labels for icon-only controls on the tool creation page to support screen reader navigation

## Testing
- `npm run build` *(fails: Missing optional dependency `@tailwindcss/postcss` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cda451eb0c832587b5853e34610b05