### PR TITLE
Align backend models with database schema

### DIFF
--- a/db/database_schema_consolidated.sql
+++ b/db/database_schema_consolidated.sql
@@ -65,7 +65,8 @@ CREATE TABLE IF NOT EXISTS user_auth (
   failed_attempts integer NOT NULL DEFAULT 0,
   locked_until bigint,
   auth_method text NOT NULL DEFAULT 'password',
-  requires_password_change boolean NOT NULL DEFAULT false
+  requires_password_change boolean NOT NULL DEFAULT false,
+  session_nonce text NOT NULL DEFAULT encode(gen_random_bytes(16), 'hex')
 );
 CREATE TRIGGER trg_user_auth_updated_at
   BEFORE UPDATE ON user_auth


### PR DESCRIPTION
## Summary
- sync SQLAlchemy models for user metadata, chat, folders, groups, and BYOM entities with the consolidated database schema so the backend exposes the same columns and defaults as the database
- allow created tools to omit an explicit entrypoint and relax created model base model IDs to match the schema
- add the missing `session_nonce` definition to the consolidated schema for `user_auth`

## Testing
- python -m compileall backend/app/db/models.py

------
https://chatgpt.com/codex/tasks/task_e_68cf8081f77c8325a13cb92bc0b939e2