### PR TITLE
Add prompts and tools helpers for creation station

### DIFF
--- a/web/src/lib/api.creationstation.ts
+++ b/web/src/lib/api.creationstation.ts
@@ -14,8 +14,26 @@ export interface PromptSummary {
   command: string;
   title?: string | null;
   content: string;
-  updated_at?: number | null;
+  updated_at?: string | number | null;
 }
+
+export type PromptUpdatePayload = Partial<PromptPayload>;
+
+type PromptResponse = {
+  id: string;
+  command: string;
+  title?: string | null;
+  content: string;
+  updated_at?: string | number | null;
+};
+
+const mapPromptSummary = (prompt: PromptResponse): PromptSummary => ({
+  id: prompt.id,
+  command: prompt.command,
+  title: prompt.title ?? undefined,
+  content: prompt.content,
+  updated_at: prompt.updated_at ?? undefined,
+});
 
 export interface ToolPayload {
   slug: string;
@@ -39,10 +57,36 @@ export interface ToolSummary {
   language: string;
   entrypoint: string;
   is_active: boolean;
-  updated_at?: number | null;
+  updated_at?: string | number | null;
   content: string;
   requirements?: string | null;
 }
+
+export type ToolUpdatePayload = Partial<ToolPayload>;
+
+type ToolResponse = {
+  id: string;
+  slug: string;
+  name: string;
+  language?: string | null;
+  entrypoint?: string | null;
+  is_active?: boolean | null;
+  updated_at?: string | number | null;
+  content: string;
+  requirements?: string | null;
+};
+
+const mapToolSummary = (tool: ToolResponse): ToolSummary => ({
+  id: tool.id,
+  slug: tool.slug,
+  name: tool.name,
+  language: tool.language ?? 'python',
+  entrypoint: tool.entrypoint ?? 'run',
+  is_active: tool.is_active ?? true,
+  updated_at: tool.updated_at ?? undefined,
+  content: tool.content,
+  requirements: tool.requirements ?? undefined,
+});
 
 export interface ModelPayload {
   base_model_id: string;
@@ -84,6 +128,7 @@ export interface RoomCreatePayload {
   data?: Record<string, unknown>;
   meta?: Record<string, unknown>;
   access_control?: Record<string, unknown>;
+  member_ids?: string[];
 }
 
 export interface RoomSummary {
@@ -98,43 +143,24 @@ export interface RoomSummary {
   meta: Record<string, unknown>;
 }
 
-export type RoomSummary = {
-  id: string;
-  name: string;
-  description?: string | null;
-  member_count: number;
-  is_archived: boolean;
-  created_at?: number | null;
-};
-
-export type RoomCreatePayload = {
-  name: string;
-  description?: string;
-  channel_type?: string;
-  data?: Record<string, any>;
-  meta?: Record<string, any>;
-  access_control?: Record<string, any>;
-  member_ids?: string[];
-};
-
 export type RoomUpdatePayload = Partial<Omit<RoomCreatePayload, 'member_ids'>>;
 
-export type RoomMessageIn = {
+export interface RoomMessageIn {
   content: string;
   parent_id?: string | null;
   target_user_id?: string | null;
-  data?: Record<string, any>;
-  meta?: Record<string, any>;
-};
+  data?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+}
 
-export type RoomMessageOut = {
+export interface RoomMessageOut {
   id: string;
   user_id: string;
   class_room_id: string;
   content: string;
   created_at?: number | null;
   parent_id?: string | null;
-};
+}
 
 export type ChatMessage = {
   role: 'system' | 'user' | 'assistant';
@@ -146,10 +172,52 @@ export type AssistantResponse = {
   suggestions: string[];
 };
 
-export const creationAPI = {
-  prompts: {
-
+export const prompts = {
+  list: async (): Promise<PromptSummary[]> => {
+    const response = await api.get<PromptResponse[]>('/api/v1/prompts');
+    return response.map(mapPromptSummary);
   },
+  get: async (promptId: string): Promise<PromptSummary> => {
+    const response = await api.get<PromptResponse>(`/api/v1/prompts/${promptId}`);
+    return mapPromptSummary(response);
+  },
+  create: async (body: PromptPayload): Promise<PromptSummary> => {
+    const response = await api.post<PromptResponse>('/api/v1/prompts', body);
+    return mapPromptSummary(response);
+  },
+  update: async (
+    promptId: string,
+    body: PromptUpdatePayload,
+  ): Promise<PromptSummary> => {
+    const response = await api.patch<PromptResponse>(`/api/v1/prompts/${promptId}`, body);
+    return mapPromptSummary(response);
+  },
+  remove: (promptId: string) => api.delete<void>(`/api/v1/prompts/${promptId}`),
+};
+
+export const tools = {
+  list: async (): Promise<ToolSummary[]> => {
+    const response = await api.get<ToolResponse[]>('/api/v1/tools');
+    return response.map(mapToolSummary);
+  },
+  get: async (toolId: string): Promise<ToolSummary> => {
+    const response = await api.get<ToolResponse>(`/api/v1/tools/${toolId}`);
+    return mapToolSummary(response);
+  },
+  create: async (body: ToolPayload): Promise<ToolSummary> => {
+    const response = await api.post<ToolResponse>('/api/v1/tools', body);
+    return mapToolSummary(response);
+  },
+  update: async (toolId: string, body: ToolUpdatePayload): Promise<ToolSummary> => {
+    const response = await api.patch<ToolResponse>(`/api/v1/tools/${toolId}`, body);
+    return mapToolSummary(response);
+  },
+  remove: (toolId: string) => api.delete<void>(`/api/v1/tools/${toolId}`),
+};
+
+export const creationAPI = {
+  prompts,
+  tools,
   libraries: {
     list: () => api.get<LibrarySummary[]>('/api/v1/libraries'),
     create: (body: LibraryPayload) => api.post<LibrarySummary>('/api/v1/libraries', body),
@@ -157,14 +225,9 @@ export const creationAPI = {
   rooms: {
     list: () => api.get<RoomSummary[]>('/api/v1/rooms'),
     create: (body: RoomCreatePayload) => api.post<RoomSummary>('/api/v1/rooms', body),
-    archive: (roomId: string) => api.post<RoomSummary>(`/api/v1/rooms/${roomId}/archive`, {}),
-    restore: (roomId: string) => api.post<RoomSummary>(`/api/v1/rooms/${roomId}/restore`, {}),
-  },
-  rooms: {
-    list: () => api.get<RoomSummary[]>('/api/v1/rooms'),
-    create: (body: RoomCreatePayload) => api.post<RoomSummary>('/api/v1/rooms', body),
     update: (roomId: string, body: RoomUpdatePayload) => api.patch<RoomSummary>(`/api/v1/rooms/${roomId}`, body),
     archive: (roomId: string) => api.post<RoomSummary>(`/api/v1/rooms/${roomId}/archive`, {}),
+    restore: (roomId: string) => api.post<RoomSummary>(`/api/v1/rooms/${roomId}/restore`, {}),
     remove: (roomId: string) => api.delete<void>(`/api/v1/rooms/${roomId}`),
     messages: {
       list: (roomId: string, limit = 50) => api.get<RoomMessageOut[]>(`/api/v1/rooms/${roomId}/messages?limit=${limit}`),

--- a/web/src/routes/creation-station/prompts/+page.svelte
+++ b/web/src/routes/creation-station/prompts/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { creationAPI, type PromptSummary } from '$lib/api.creationstation';
+  import { prompts as promptsAPI, type PromptSummary } from '$lib/api.creationstation';
 
   const preview = (content: string, limit = 160) =>
     content.length > limit ? `${content.slice(0, limit)}…` : content;
@@ -18,7 +18,7 @@
   
   onMount(async () => {
     try {
-      prompts = await creationAPI.prompts.list();
+      prompts = await promptsAPI.list();
     } catch (err) {
       error = err instanceof Error ? err.message : 'Failed to load prompts';
     } finally {

--- a/web/src/routes/creation-station/tools/+page.svelte
+++ b/web/src/routes/creation-station/tools/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { creationAPI, type ToolSummary } from '$lib/api.creationstation';
+  import { tools as toolsAPI, type ToolSummary } from '$lib/api.creationstation';
 
   const preview = (content: string, limit = 160) =>
     content.length > limit ? `${content.slice(0, limit)}…` : content;
@@ -19,7 +19,7 @@
   
   async function loadTools() {
     try {
-      const result = await creationAPI.tools.list();
+      const result = await toolsAPI.list();
       tools = result;
       error = null;
     } catch (err) {

--- a/web/src/routes/creation-station/tools/new/+page.svelte
+++ b/web/src/routes/creation-station/tools/new/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { creationAPI } from '$lib/api.creationstation';
+  import { tools } from '$lib/api.creationstation';
   import type { ChatMessage } from '$lib/api.creationstation';
   import { goto } from '$app/navigation';
   import MonacoEditor from '$lib/components/MonacoEditor.svelte';
@@ -41,7 +41,7 @@
     error = null;
 
     try {
-      await creationAPI.tools.create({
+      await tools.create({
         slug,
         name,
         language,

--- a/web/src/routes/tools/+page.svelte
+++ b/web/src/routes/tools/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { creationAPI } from '$lib/api.creationstation';
+  import { tools as toolsAPI } from '$lib/api.creationstation';
 
   let tools: Array<{ id: string; name: string; slug: string; language: string }> = [];
   let status: 'loading' | 'ready' | 'error' = 'loading';
@@ -8,7 +8,7 @@
 
   onMount(async () => {
     try {
-      const data = await creationAPI.tools.list();
+      const data = await toolsAPI.list();
       tools = data ?? [];
       status = 'ready';
     } catch (err) {

--- a/web/src/routes/tools/new/+page.svelte
+++ b/web/src/routes/tools/new/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { creationAPI } from '$lib/api.creationstation';
+  import { tools } from '$lib/api.creationstation';
   import { goto } from '$app/navigation';
 
   let slug = '';
@@ -19,7 +19,7 @@
     error = null;
 
     try {
-      await creationAPI.tools.create({
+      await tools.create({
         slug,
         name,
         language,


### PR DESCRIPTION
## Summary
- add normalization helpers in `api.creationstation` for prompts and tools endpoints and expose them individually alongside the `creationAPI`
- ensure prompt and tool helpers return the canonical prompt and tool fields expected by the UI
- update prompts and tools pages to import the dedicated helpers while keeping existing behaviour

## Testing
- `npm run build` *(fails: existing Svelte lint errors and rooms page block closing tag error)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b66b17a88325a71afc6a924e628d