### PR TITLE
Fix creation station room API type duplication

### DIFF
--- a/web/src/lib/api.creationstation.ts
+++ b/web/src/lib/api.creationstation.ts
@@ -77,15 +77,6 @@ export interface LibrarySummary {
   meta: Record<string, unknown>;
 }
 
-export interface RoomCreatePayload {
-  name: string;
-  description?: string;
-  channel_type?: string;
-  data?: Record<string, unknown>;
-  meta?: Record<string, unknown>;
-  access_control?: Record<string, unknown>;
-}
-
 export interface RoomSummary {
   id: string;
   name: string;
@@ -98,24 +89,15 @@ export interface RoomSummary {
   meta: Record<string, unknown>;
 }
 
-export type RoomSummary = {
-  id: string;
-  name: string;
-  description?: string | null;
-  member_count: number;
-  is_archived: boolean;
-  created_at?: number | null;
-};
-
-export type RoomCreatePayload = {
+export interface RoomCreatePayload {
   name: string;
   description?: string;
   channel_type?: string;
-  data?: Record<string, any>;
-  meta?: Record<string, any>;
-  access_control?: Record<string, any>;
+  data?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+  access_control?: Record<string, unknown>;
   member_ids?: string[];
-};
+}
 
 export type RoomUpdatePayload = Partial<Omit<RoomCreatePayload, 'member_ids'>>;
 
@@ -157,17 +139,14 @@ export const creationAPI = {
   rooms: {
     list: () => api.get<RoomSummary[]>('/api/v1/rooms'),
     create: (body: RoomCreatePayload) => api.post<RoomSummary>('/api/v1/rooms', body),
+    update: (roomId: string, body: RoomUpdatePayload) =>
+      api.patch<RoomSummary>(`/api/v1/rooms/${roomId}`, body),
     archive: (roomId: string) => api.post<RoomSummary>(`/api/v1/rooms/${roomId}/archive`, {}),
     restore: (roomId: string) => api.post<RoomSummary>(`/api/v1/rooms/${roomId}/restore`, {}),
-  },
-  rooms: {
-    list: () => api.get<RoomSummary[]>('/api/v1/rooms'),
-    create: (body: RoomCreatePayload) => api.post<RoomSummary>('/api/v1/rooms', body),
-    update: (roomId: string, body: RoomUpdatePayload) => api.patch<RoomSummary>(`/api/v1/rooms/${roomId}`, body),
-    archive: (roomId: string) => api.post<RoomSummary>(`/api/v1/rooms/${roomId}/archive`, {}),
     remove: (roomId: string) => api.delete<void>(`/api/v1/rooms/${roomId}`),
     messages: {
-      list: (roomId: string, limit = 50) => api.get<RoomMessageOut[]>(`/api/v1/rooms/${roomId}/messages?limit=${limit}`),
+      list: (roomId: string, limit = 50) =>
+        api.get<RoomMessageOut[]>(`/api/v1/rooms/${roomId}/messages?limit=${limit}`),
       create: (roomId: string, body: RoomMessageIn) =>
         api.post<RoomMessageOut>(`/api/v1/rooms/${roomId}/messages`, body),
     },


### PR DESCRIPTION
## Summary
- consolidate the creation-station room API types into a single RoomSummary/RoomCreatePayload that matches the backend schema
- expose a single creationAPI.rooms helper bundle that includes restore alongside list/create/update/archive/remove/messages

## Testing
- npm run build *(fails: existing Svelte template error at src/routes/creation-station/rooms/+page.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b668d2e08325ad9410dfe05e8a29