### PR TITLE
Add reactive filtered rooms list

### DIFF
--- a/web/src/routes/creation-station/rooms/+page.svelte
+++ b/web/src/routes/creation-station/rooms/+page.svelte
@@ -8,6 +8,15 @@
   let error: string | null = null;
   let searchQuery = '';
 
+  $: normalizedQuery = searchQuery.trim().toLowerCase();
+  $: filteredRooms = normalizedQuery
+    ? rooms.filter((room) => {
+        const name = room.name?.toLowerCase() ?? '';
+        const description = room.description?.toLowerCase() ?? '';
+        return name.includes(normalizedQuery) || description.includes(normalizedQuery);
+      })
+    : rooms;
+
 
   onMount(async () => {
     try {


### PR DESCRIPTION
## Summary
- add reactive filteredRooms list driven by the search query
- perform case-insensitive filtering on room name and description
- fall back to full room list when the query is empty

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0bad74cbc83258aae655272036ee1